### PR TITLE
Upgrade pytest and flask-sqlalchemy(fixes #69)

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -26,6 +26,6 @@ class DevelopmentConfig(Config):
             port=5432,
             databasename=os.environ.get('DB_NAME'),
         ))
-    SQLALCHEMY_POOL_RECYCLE = 299
+    SQLALCHEMY_ENGINE_OPTIONS = {'pool_recycle': 299}
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SECRET_KEY = os.environ.get('SECRET_KEY')

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,8 +1,8 @@
 Flask==1.0.2
-Flask-SQLAlchemy==2.3.1
+Flask-SQLAlchemy==2.4.0
 Flask-Migrate==2.3.0
 psycopg2==2.8.3
-pytest==4.1.1
+pytest==5.0.1
 marshmallow==3.0.0rc1
 flask-jwt-extended==3.14.0
 flask-cors==3.0.7


### PR DESCRIPTION
Because of changes in SQLAlchemy and flask-sqlalchemy i had to change 'SQLALCHEMY_POOL_RECYCLE' config option -  it is deprecated as of v2.4 and will be removed in v3.0.

To test:
- make start 
- make bash
In bash shell type pytest. There should be no warnings anymore.