### PR TITLE
improved the spacing underneath the title

### DIFF
--- a/frontend/src/components/AboutUs.vue
+++ b/frontend/src/components/AboutUs.vue
@@ -42,22 +42,7 @@
 #container {
     background: $blue;
 }
-#title {
-    font-family: $font-header;
-    font-size: 42px;
-    position: relative;
-    padding-bottom: 20px;
-}
-#title::before {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    left: 50%;
-    width: 250px;
-    height: 5px;
-    background-color: $white;
-    margin-left: -125px;
-}
+
 #content {
     font-family: $font-content;
     font-size: 20px;

--- a/frontend/src/components/JoinUs.vue
+++ b/frontend/src/components/JoinUs.vue
@@ -30,22 +30,7 @@
 #container {
     background: $blue;
 }
-#title {
-    font-family: $font-header;
-    font-size: 42px;
-    position: relative;
-    padding-bottom: 20px;
-}
-#title::before {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    left: 50%;
-    width: 250px;
-    height: 5px;
-    background-color: $white;
-    margin-left: -125px;
-}
+
 #content {
     font-family: $font-content;
     font-size: 20px;

--- a/frontend/src/scss/global.scss
+++ b/frontend/src/scss/global.scss
@@ -1,3 +1,24 @@
+@import 'typography.scss';
+@import "colors";
+
 a {
     text-decoration: none;
+}
+
+#title {
+    font-family: $font-header;
+    font-size: 42px;
+    position: relative;
+    padding-bottom: 3rem;
+}
+#title::before {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 50%;
+    width: 250px;
+    height: 5px;
+    background-color: $white;
+    margin-left: -125px;
+    margin-bottom: 2rem;
 }

--- a/frontend/src/scss/global.scss
+++ b/frontend/src/scss/global.scss
@@ -20,5 +20,5 @@ a {
     height: 5px;
     background-color: $white;
     margin-left: -125px;
-    margin-bottom: 2rem;
+    margin-bottom: 3rem;
 }


### PR DESCRIPTION
**Previously there was almost no break between the title and the content so:**
1) I added the spacing
2) Moved title and before::title classes to global scss as they are used the same across the page

**How to test it:**
1) Run docker and see if the app stands up
2) See if spacing between titles in about-us and join-us components are sufficient 
3) Check the console if it doesn't log any errors