### PR TITLE
Added code coverage tool (fixes #195)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ __pycache__/
 *.egg-info/
 .idea/
 *.idea
+*.coverage
+htmlcov/

--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,9 @@ rebuild: ## Rebuild docker images
 
 test: 	## Run unittests
 	docker-compose exec backend pytest
+
+code-cov: ## Run pytest with code coverage
+	docker-compose exec backend pytest --cov=backend
+
+cov-report: ## Generate coverage raport in HTML
+	docker-compose exec backend pytest --cov=backend --cov-report=html

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,3 +10,4 @@ Flask-Mail==0.9.1
 factory_boy==2.11.1
 tqdm==2.2.3
 flask-restful==0.3.7
+pytest-cov==2.8.1


### PR DESCRIPTION
- make start

Show code-coverage in terminal's output:
make code-cov

Generate code-coverage report to html
make cov-report
Then open from project directory htmlcov/index.html to see report details