### PR TITLE
Add jwt token in blacklist loader (fixes #208)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -3,6 +3,7 @@ from flask_cors import CORS
 
 from backend.commands.populate_database import populate_database
 from backend.extensions import api, db, mail, migrate, jwt
+from backend.models import JWTToken
 from backend.resources.auth import (
     UserLogin,
     UserLogout,
@@ -30,9 +31,15 @@ def initialize_extensions(app):
     """Helper functions"""
     api.init_app(app)
     db.init_app(app)
+    jwt.init_app(app)
     mail.init_app(app)
     migrate.init_app(app, db, directory="migrations")
-    jwt.init_app(app)
+
+    @jwt.token_in_blacklist_loader
+    def check_if_token_in_blacklist(decrypted_token):
+        """Checking if token is blacklisted"""
+        jti = decrypted_token["jti"]
+        return JWTToken.is_jti_blacklisted(jti)
 
 
 api.add_resource(HacknightList, "/hacknights/")

--- a/backend/config.py
+++ b/backend/config.py
@@ -27,3 +27,5 @@ class DevelopmentConfig(Config):
     SQLALCHEMY_ENGINE_OPTIONS = {"pool_recycle": 299}
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SECRET_KEY = os.environ.get("SECRET_KEY")
+
+    JWT_BLACKLIST_ENABLED = True

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,4 +1,5 @@
 from sqlalchemy import Column
+from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.types import Boolean
 from sqlalchemy.types import Date
 from sqlalchemy.types import DateTime
@@ -71,3 +72,11 @@ class JWTToken(db.Model):
     user_identity = Column(String(200), nullable=False)
     revoked = Column(Boolean, nullable=False)
     expires = Column(DateTime, nullable=False)
+
+    @classmethod
+    def is_jti_blacklisted(cls, jti):
+        try:
+            token = cls.query.filter_by(jti=jti).one()
+            return token.revoked
+        except NoResultFound:
+            return True

--- a/backend/resources/auth.py
+++ b/backend/resources/auth.py
@@ -80,12 +80,6 @@ class UserLogout(Resource):
 class RefreshAccessToken(Resource):
     @jwt_refresh_token_required
     def post(self):
-        jti = get_raw_jwt()["jti"]
-        token = JWTToken.query.filter_by(jti=jti).one()
-
-        if token.revoked:
-            return {"msg": "token has been revoked"}, HTTPStatus.UNAUTHORIZED
-
         current_user = get_jwt_identity()
         identity_claim = app.config["JWT_IDENTITY_CLAIM"]
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -93,10 +93,11 @@ def registered_user(new_user, app, _db):
 
 
 @pytest.fixture
-def access_token(client, new_user, registered_user):
-    rv = client.post("/auth/login/", json=new_user)
-    access_token = rv.get_json()["access_token"]
-    return access_token
+def access_token(app, _db, client, new_user, registered_user):
+    with app.app_context():
+        rv = client.post("/auth/login/", json=new_user)
+        access_token = rv.get_json()["access_token"]
+        yield access_token
 
 
 @pytest.fixture


### PR DESCRIPTION
At first populate database.
Login (sent post request to "auth/login/" with username and password in body), and try to get data from protected route e.g. /participants/ adding to headers: {"Authorization": "Bearer <yours access_token>" . Data should be returned correctly with 200 status code
Then sent delete request to "/auth/logout/" with yours access_token in headers.
After successfully logging out, try to get data from protected route again with these same access_token. 
You should get back 401 status code and fallowing message:
{
  "msg": "Token has been revoked"
} 