### PR TITLE
[295] Populate database unique constraint fix

### DIFF
--- a/backend/factories.py
+++ b/backend/factories.py
@@ -22,13 +22,15 @@ class UserFactory(BaseFactory):
     def _create(cls, model_class, *args, **kwargs):
         session = cls._meta.sqlalchemy_session
         with session.no_autoflush:
-            obj = (
+            existing = (
                 session.query(model_class)
                 .filter_by(username=kwargs["username"])
                 .first()
             )
-        if not obj:
-            obj = super(UserFactory, cls)._create(model_class, *args, **kwargs)
+        if existing:
+            kwargs["username"] = cls.username.generate({})
+
+        obj = super(UserFactory, cls)._create(model_class, *args, **kwargs)
 
         return obj
 
@@ -51,7 +53,7 @@ class ParticipantFactory(BaseFactory):
     def _create(cls, model_class, *args, **kwargs):
         session = cls._meta.sqlalchemy_session
         with session.no_autoflush:
-            obj = (
+            existing = (
                 session.query(model_class)
                 .filter(
                     or_(
@@ -61,8 +63,11 @@ class ParticipantFactory(BaseFactory):
                 )
                 .first()
             )
-        if not obj:
-            obj = super(ParticipantFactory, cls)._create(model_class, *args, **kwargs)
+        if existing:
+            kwargs["email"] = cls.email.generate({})
+            kwargs["github"] = cls.github.generate({})
+
+        obj = super(ParticipantFactory, cls)._create(model_class, *args, **kwargs)
 
         return obj
 
@@ -77,10 +82,12 @@ class HacknightFactory(BaseFactory):
     def _create(cls, model_class, *args, **kwargs):
         session = cls._meta.sqlalchemy_session
         with session.no_autoflush:
-            obj = session.query(model_class).filter_by(date=kwargs["date"]).first()
+            existing = session.query(model_class).filter_by(date=kwargs["date"]).first()
 
-        if not obj:
-            obj = super(HacknightFactory, cls)._create(model_class, *args, **kwargs)
+        if existing:
+            kwargs["date"] = cls.date.generate({})
+
+        obj = super(HacknightFactory, cls)._create(model_class, *args, **kwargs)
 
         return obj
 


### PR DESCRIPTION
#### Story / Bug id:
[295](https://github.com/CodeForPoznan/codeforpoznan.pl_v3/issues/295)

#### Description:
If object with unique constraint created by factory existed in db, new object with random arguments would be created. 
In previous solution factory was returning object from db if existed instead of not creating new object.

#### Migrations:
N/A

#### New imports / dependencies:
N/A

#### What tests do I need to run to validate this change:
The following command will run previously failing test twenty times:
`docker-compose exec  backend bash -c 'for i in {1..20}; do pytest --pdb tests/test_commands.py::test_populate_database; done'`
