### PR TITLE
backend/Dockerfile: fix failing build, pin pipenv version

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,19 +2,20 @@ FROM python:3.8
 
 EXPOSE 5000
 
-RUN apt-get update -y && apt-get install -y libpq-dev wait-for-it && apt-get autoremove
+RUN apt-get update -y \
+    && apt-get install -y \
+        libpq-dev \
+        wait-for-it \
+    && apt-get autoremove
 
-# update pip
-RUN pip install --upgrade pip
-
-ADD . /cfp_v3/backend
 WORKDIR /cfp_v3/backend
 
 COPY Pipfile Pipfile.lock ./
-RUN pip install --upgrade pip && \
-    pip install pipenv && \
-    pipenv install
 
-RUN chmod +x docker-entrypoint.sh
+RUN pip install --upgrade pip \
+    && pip install pipenv==v2020.11.15 \
+    && pipenv install --system
 
-ENTRYPOINT bash docker-entrypoint.sh
+ADD . /cfp_v3/backend
+
+ENTRYPOINT ["bash", "docker-entrypoint.sh"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -14,7 +14,7 @@ COPY Pipfile Pipfile.lock ./
 
 RUN pip install --upgrade pip \
     && pip install pipenv==v2020.11.15 \
-    && pipenv install --system
+    && pipenv install --system --deploy
 
 ADD . /cfp_v3/backend
 


### PR DESCRIPTION
#### Description:
I have fixed the `flask command not found` error showing up when you start the project.

I also corrected few smaller things along the way (hope you don't mind that!).

Here's list of things that I did:
- aligned the apt install commands for increased readability
- removed redundant pip upgrade
- moved `ADD` statement to the end for better cache usability
- removed not needed `chmod` (we're using `bash docker-entrypoint.sh` anyway, so `+x` does not make a difference)
- pinned `pipenv` version [1]
- instructed `pipenv` that it should install packages globally and that it should respect lock file [2]
- wrapped entrypoint with square brackets notation [3]

[1]. This is important because we were prone to situation where new pipenv release breaks our pipeline without us noticing that after a while (which is what happened here).
[2]. This is important, because pipenv changed the defaults some time ago (I don't know in which release) causing the installation to fail because it tried to install the packages locally for some reason. And because`ADD` was before `pipenv install`, the `.venv` happened to be on the container already, thus breaking the installation silently.
[3]. This is important, because it will speed up `docker stop/rm` of containers (they don't respect UNIX signals if not wrapped with square brackets.

More info on the pipenv flags:
```
--system — Use the system pip command rather than the one from your virtualenv.
--deploy — Make sure the packages are properly locked in Pipfile.lock, and abort if the lock file is out-of-date.
```
source: https://pipenv-fork.readthedocs.io/en/latest/basics.html


#### Migrations:
N/A

#### New imports / dependencies:
N/A

#### What tests do I need to run to validate this change:
```bash
docker-compose down --volumes

make start  # :)
```