### PR TITLE
Fix port number for lambda config

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -19,7 +19,7 @@ class DevelopmentConfig(Config):
     DB_USER = os.environ.get("DB_USER")
     DB_PASSWORD = os.environ.get("DB_PASSWORD")
     DB_HOST = os.environ.get("DB_HOST")
-    DB_PORT = os.environ.get("DB_PORT")
+    DB_PORT = os.environ.get("DB_PORT") or 5432
     DB_NAME = os.environ.get("DB_NAME")
 
     SQLALCHEMY_DATABASE_URI = (


### PR DESCRIPTION
uhh, sorry :)

broke that here: 
https://github.com/CodeForPoznan/codeforpoznan.pl_v3/commit/6aa633094693170492840a0a81e0343a9cb9f7a5#diff-651976572b51d1a16ede6a1c4c1be9a1482605ce57ca58fbfca25e4a55c43210L22

AWS lambda does not have PORT configuration:
https://github.com/CodeForPoznan/Infrastructure/blob/master/dev_codeforpoznan_pl_v3.tf#L116

so it failed at runtime: 
```
[ERROR] ValueError: invalid literal for int() with base 10: 'None'
Traceback (most recent call last):
  File "/var/task/backend/handlers.py", line 15, in api
    return handle_request(create_app(), event, context)
```