### PR TITLE
[308] Contact us alerts timeout (fixes#308)

### DIFF
--- a/frontend/src/store/modules/contact.js
+++ b/frontend/src/store/modules/contact.js
@@ -17,12 +17,14 @@ export default {
   mutations: {
     setWasSent(state) {
       state.msgWasSent = true;
+      setTimeout(() => (state.msgWasSent = false), 5000);
     },
     setWasntSent(state) {
       state.msgWasSent = false;
     },
     raiseMsgError(state) {
       state.msgError = true;
+      setTimeout(() => (state.msgError = false), 5000);
     },
     clearError(state) {
       state.msgError = false;


### PR DESCRIPTION
#### Story / Bug id:
[308](https://github.com/CodeForPoznan/codeforpoznan.pl_v3/issues/308)

#### Description:
Timeout was set for contact us form alerts (both successful and error) 

#### Migrations:
N/A

#### New imports / dependencies:
N/A

#### What tests do I need to run to validate this change:
Send message from contact form. Alert should disappear after 5s.
