### PR TITLE
[371] Participants alphabetical order (fixes#371)

### DIFF
--- a/frontend/src/components/HacknightsParticipants.vue
+++ b/frontend/src/components/HacknightsParticipants.vue
@@ -5,16 +5,7 @@
         <v-combobox
           v-model="selectedParticipants"
           outlined
-          :items="
-            getParticipants
-              .filter(
-                participant =>
-                  !getHacknight.participants.filter(
-                    y => y.id === participant.id
-                  ).length
-              )
-              .sort((a, b) => a.github.localeCompare(b.github))
-          "
+          :items="filerOutParticipants()"
           item-text="github"
           item-value="github"
           :search-input.sync="search"
@@ -94,6 +85,26 @@ export default {
         .dispatch('hacknight/addParticipants', ids)
         .then(() => (this.selectedParticipants = []));
     },
+    // filerOutParticipants() {
+    //     return this.getParticipants
+    //       .filter(
+    //         participant =>
+    //           !this.getHacknight.participants.filter(
+    //             y => y.id === participant.id
+    //           ).length
+    //       )
+    //       .sort((a, b) => a.github.localeCompare(b.github))
+    //   },
+      filerOutParticipants() {
+        return this.getParticipants
+          .filter(
+            participant =>
+              !this.getHacknight.participants.some(
+                hacknightParticipant => hacknightParticipant.id === participant.id
+              )
+          )
+          .sort((a, b) => a.github.localeCompare(b.github))
+      },
     orderedParticipants() {
       return _.sortBy(this.getHacknight.participants, participant =>
         participant.github.toLowerCase()

--- a/frontend/src/components/HacknightsParticipants.vue
+++ b/frontend/src/components/HacknightsParticipants.vue
@@ -6,11 +6,14 @@
           v-model="selectedParticipants"
           outlined
           :items="
-            getParticipants.filter(
-              participant =>
-                !getHacknight.participants.filter(y => y.id === participant.id)
-                  .length
-            )
+            getParticipants
+              .filter(
+                participant =>
+                  !getHacknight.participants.filter(
+                    y => y.id === participant.id
+                  ).length
+              )
+              .sort((a, b) => a.github.localeCompare(b.github))
           "
           item-text="github"
           item-value="github"
@@ -59,7 +62,7 @@
       </v-toolbar>
       <v-divider v-if="getHacknight.participants"></v-divider>
       <v-list>
-        <template v-for="(item, i) in getHacknight.participants">
+        <template v-for="(item, i) in orderedParticipants()">
           <v-list-item v-if="getHacknight.participants" :key="i">
             <v-list-item-avatar>
               <v-icon>mdi-account-outline</v-icon>
@@ -74,6 +77,7 @@
 
 <script>
 import { mapGetters } from 'vuex';
+import _ from 'lodash';
 export default {
   data() {
     return {
@@ -89,6 +93,11 @@ export default {
       this.$store
         .dispatch('hacknight/addParticipants', ids)
         .then(() => (this.selectedParticipants = []));
+    },
+    orderedParticipants() {
+      return _.sortBy(this.getHacknight.participants, participant =>
+        participant.github.toLowerCase()
+      );
     }
   },
   computed: {

--- a/frontend/src/components/HacknightsParticipants.vue
+++ b/frontend/src/components/HacknightsParticipants.vue
@@ -85,26 +85,16 @@ export default {
         .dispatch('hacknight/addParticipants', ids)
         .then(() => (this.selectedParticipants = []));
     },
-    // filerOutParticipants() {
-    //     return this.getParticipants
-    //       .filter(
-    //         participant =>
-    //           !this.getHacknight.participants.filter(
-    //             y => y.id === participant.id
-    //           ).length
-    //       )
-    //       .sort((a, b) => a.github.localeCompare(b.github))
-    //   },
-      filerOutParticipants() {
-        return this.getParticipants
-          .filter(
-            participant =>
-              !this.getHacknight.participants.some(
-                hacknightParticipant => hacknightParticipant.id === participant.id
-              )
-          )
-          .sort((a, b) => a.github.localeCompare(b.github))
-      },
+    filerOutParticipants() {
+      return this.getParticipants
+        .filter(
+          participant =>
+            !this.getHacknight.participants.some(
+              hacknightParticipant => hacknightParticipant.id === participant.id
+            )
+        )
+        .sort((a, b) => a.github.localeCompare(b.github));
+    },
     orderedParticipants() {
       return _.sortBy(this.getHacknight.participants, participant =>
         participant.github.toLowerCase()


### PR DESCRIPTION
#### Story / Bug id:
[371](https://github.com/CodeForPoznan/codeforpoznan.pl_v3/issues/371)

#### Description:
Participants should be now order alphabetically by github in both hacknight's participants list and participant dropdown.

#### Migrations:
N/A

#### New imports / dependencies:
N/A

#### What tests do I need to run to validate this change:
From dashboard component select hacknight, check whether participants list is in alphabetical order, try to add new participant - github names from dropdown should be sorted too.
