### PR TITLE
Create ParticipantsSearch component and use it in Participants form

### DIFF
--- a/frontend/src/components/Participants.vue
+++ b/frontend/src/components/Participants.vue
@@ -63,19 +63,7 @@
         </v-tab>
       </v-tabs>
       <v-card-text v-if="editParticipant">
-        <v-select
-          :items="
-            [...getParticipants].sort((a, b) =>
-              a.github.localeCompare(b.github)
-            )
-          "
-          item-text="github"
-          item-value="id"
-          label="Select Participant"
-          v-model="selectedParticipant"
-          @input="onPopulateForm"
-        >
-        </v-select>
+        <ParticipantsSearch v-model="selectedParticipant" />
       </v-card-text>
       <v-divider></v-divider>
       <v-form @keyup.enter="onSubmit" class="pa-6" ref="form">
@@ -177,6 +165,7 @@
 </template>
 
 <script>
+import ParticipantsSearch from './ParticipantsSearch.vue';
 import { mapGetters } from 'vuex';
 import {
   required,
@@ -210,6 +199,9 @@ export default {
       dialog: false,
       selectedTab: 0
     };
+  },
+  components: {
+    ParticipantsSearch
   },
   validations: {
     form: {
@@ -262,7 +254,7 @@ export default {
       if (this.selectedParticipant) {
         this.editParticipant = true;
         this.$store
-          .dispatch('participant/getParticipant', this.selectedParticipant)
+          .dispatch('participant/getParticipant', this.selectedParticipant.id)
           .then(() => {
             const selectedParticipant = this.getParticipant;
 
@@ -277,7 +269,6 @@ export default {
         .dispatch('participant/editParticipant', { ...this.form })
         .then(status => {
           if (status === 200) {
-            this.selectedParticipant = this.getParticipant;
             this.successAlert = 'Participant has been successfully edited';
             this.resetForm();
             setTimeout(() => (this.successAlert = ''), 5000);
@@ -363,6 +354,11 @@ export default {
       this.warningMessage =
         'This phone number already exists. Please verify if a person is actually a new paricipant';
       setTimeout(() => (this.warningAlert = false), 10000);
+    }
+  },
+  watch: {
+    selectedParticipant(newValue) {
+      newValue ? this.onPopulateForm() : this.resetForm();
     }
   },
   computed: {

--- a/frontend/src/components/ParticipantsSearch.vue
+++ b/frontend/src/components/ParticipantsSearch.vue
@@ -1,0 +1,53 @@
+<template>
+  <v-combobox
+    clearable
+    label="Search participants"
+    :items="sortedParticipants"
+    item-text="github"
+    :filter="filterParticipants"
+    v-model="selectedParticipant"
+  ></v-combobox>
+</template>
+
+<script>
+import { mapGetters } from 'vuex';
+
+export default {
+  props: {
+    value: {
+      type: Object | null,
+      required: true
+    }
+  },
+  computed: {
+    ...mapGetters('participant', {
+      getParticipants: 'getParticipants'
+    }),
+    sortedParticipants() {
+      return this.getParticipants.sort((a, b) =>
+        a.github.localeCompare(b.github)
+      );
+    },
+    selectedParticipant: {
+      get() {
+        return this.value;
+      },
+      set(selectedParticipant) {
+        this.$emit('input', selectedParticipant);
+      }
+    }
+  },
+  methods: {
+    filterParticipants(item, queryText) {
+      return Object.values(item).some(
+        value =>
+          value &&
+          value
+            .toString()
+            .toLowerCase()
+            .includes(queryText.toLowerCase())
+      );
+    }
+  }
+};
+</script>

--- a/frontend/src/components/ParticipantsSearch.vue
+++ b/frontend/src/components/ParticipantsSearch.vue
@@ -15,8 +15,7 @@ import { mapGetters } from 'vuex';
 export default {
   props: {
     value: {
-      type: Object | null,
-      required: true
+      type: Object
     }
   },
   computed: {
@@ -24,9 +23,9 @@ export default {
       getParticipants: 'getParticipants'
     }),
     sortedParticipants() {
-      return this.getParticipants.sort((a, b) =>
-        a.github.localeCompare(b.github)
-      );
+      const participants = this.getParticipants;
+
+      return participants.sort((a, b) => a.github.localeCompare(b.github));
     },
     selectedParticipant: {
       get() {

--- a/frontend/src/components/ParticipantsSearch.vue
+++ b/frontend/src/components/ParticipantsSearch.vue
@@ -6,7 +6,19 @@
     :item-text="displayText"
     :filter="filterParticipants"
     v-model="selectedParticipant"
-  ></v-combobox>
+    :search-input.sync="search"
+  >
+    <template v-slot:no-data>
+      <v-list-item>
+        <v-list-item-content>
+          <v-list-item-title>
+            No results matching "<strong>{{ search }}</strong
+            >".
+          </v-list-item-title>
+        </v-list-item-content>
+      </v-list-item>
+    </template>
+  </v-combobox>
 </template>
 
 <script>

--- a/frontend/src/components/ParticipantsSearch.vue
+++ b/frontend/src/components/ParticipantsSearch.vue
@@ -3,7 +3,7 @@
     clearable
     label="Search participants"
     :items="sortedParticipants"
-    item-text="github"
+    :item-text="displayText"
     :filter="filterParticipants"
     v-model="selectedParticipant"
   ></v-combobox>
@@ -25,14 +25,17 @@ export default {
     sortedParticipants() {
       const participants = this.getParticipants;
 
-      return participants.sort((a, b) => a.github.localeCompare(b.github));
+      return participants.sort((a, b) => a.first_name.localeCompare(b.github));
     },
     selectedParticipant: {
       get() {
         return this.value;
       },
       set(selectedParticipant) {
-        this.$emit('input', selectedParticipant);
+        const newSelectedParticipant =
+          typeof selectedParticipant === 'object' ? selectedParticipant : null;
+
+        this.$emit('input', newSelectedParticipant);
       }
     }
   },
@@ -46,6 +49,11 @@ export default {
             .toLowerCase()
             .includes(queryText.toLowerCase())
       );
+    },
+    displayText(participant) {
+      const { first_name, last_name, slack, github } = participant;
+
+      return `${first_name} ${last_name} (${slack}/${github})`;
     }
   }
 };


### PR DESCRIPTION
#### Story / Bug id:
https://github.com/CodeForPoznan/codeforpoznan.pl_v3/issues/56

#### Description:
Added ParticipantsSearch component and used it in Participants form to replace v-select.

#### Migrations:
N/A

#### New imports / dependencies:
N/A

#### What tests do I need to run to validate this change:

1. Go to 'Edit existing participant' form and make sure that participant can be found in searchbox by any related data (slack, github, name, last name, email, phone number, id). 
2. Sanity testing of all the functionalities in this form (ie. you can edit participant, save changes, then search by changed data; you can clear the form; you can switch between 'edit' and 'add' mode without any disturbance).
