### PR TITLE
ignore vscode extenstion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ htmlcov/
 .envrc.*
 frontend/coverage/
 frontend/dist/
-
+.vscode/


### PR DESCRIPTION
#### Story / Bug id:
No ticket provided

#### Description:
Until we get back to @arturtamborski idea about providing some basic config for vscode for CFP projects I added this to gitignore, so I won't push my config by omission in the future. 