### PR TITLE
[493] Date filter for Hacknight

### DIFF
--- a/backend/serializers/hacknight_serializer.py
+++ b/backend/serializers/hacknight_serializer.py
@@ -1,4 +1,4 @@
-from marshmallow import Schema, fields
+from marshmallow import Schema, fields, pre_load
 
 
 class HacknightSchema(Schema):
@@ -12,3 +12,13 @@ class HacknightSchema(Schema):
         "ParticipantSchema", exclude=("hacknights",), many=True
     )
     date = fields.Date()
+
+
+class DateFilterSchema(Schema):
+    start_date = fields.Date(data_key="startDate")
+    end_date = fields.Date(data_key="endDate")
+
+    @pre_load
+    def remove_empty_value(self, data, many, **kwargs):
+        """Remove field whenever value is empty string."""
+        return {key: value for key, value in data.items() if value}


### PR DESCRIPTION
#### Story / Bug id:
[493](https://github.com/CodeForPoznan/codeforpoznan.pl_v3/issues/493)

#### Description:
Only particiapt's id is returned from hacknight list endpoint. Filtering by date is enabled

#### Migrations:
N/A

#### New imports / dependencies:
N/A

#### What tests do I need to run to validate this change:
Verify if frontend is working as before. Hit the hackinigs list enpoint with some date range e.g. http://localhost:5000/api/hacknights/?startDate=2008-08-15&endDate=2008-08-16
