### PR TITLE
Revert "Bump actions tag (#500)"

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: CodeForPoznan/actions/setup-backend@v1.1
+      - uses: CodeForPoznan/actions/setup-backend@v1
 
       - run: pipenv run black --check .
       - run: pipenv run pytest


### PR DESCRIPTION
This reverts commit 4dd88304329f649b8bab252b14084e84f60c6a1b.

Let's check if Github Actions works with major/minor versioning. 