### PR TITLE
Container shutdown speed fix

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -92,7 +92,7 @@ class StagingConfig(Config):
 
 class DevelopmentConfig(Config):
     """
-    Used for https://localhost:8088/ (Docker)
+    Used for https://localhost:8080/ (Docker)
     """
 
     pass

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -8,4 +8,4 @@ getent hosts host.docker.internal >/dev/null || \
 wait-for-it "${DB_HOST}:${DB_PORT}"
 flask db migrate
 flask db upgrade
-flask run --host=0.0.0.0
+exec flask run --host=0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - ./frontend:/cfp_v3/frontend
     environment:
       - VUE_APP_AXIOS_BASE_URL=http://0.0.0.0:5000/
+    init: true
 
   backend:
     container_name: cfp_v3_backend
@@ -36,6 +37,7 @@ services:
       MAIL_USERNAME: ${MAIL_USERNAME:-}
       MAIL_PASSWORD: ${MAIL_PASSWORD:-}
       MAIL_SUPPRESS_SEND: ${MAIL_SUPPRESS_SEND:-TRUE}
+    init: true
 
   db:
     container_name: cfp_v3_db

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,6 +5,6 @@ EXPOSE 8080
 ADD . /cfp_v3/frontend
 WORKDIR /cfp_v3/frontend
 
-RUN yarn install
+RUN ["yarn", "install"]
 
-ENTRYPOINT bash docker-entrypoint.sh
+ENTRYPOINT ["bash", "docker-entrypoint.sh"]

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
-
 # https://github.com/docker/for-linux/issues/264
 getent hosts host.docker.internal >/dev/null || \
     echo "$(ip route list match 0/0 | cut -d' ' -f3) host.docker.internal" \
     | tee -a /etc/hosts >/dev/null
 
 yarn install
-yarn serve --host 0.0.0.0
+exec yarn serve --host 0.0.0.0


### PR DESCRIPTION
#### Story / Bug id:
N/A

#### Description:
Adds minor optimization and speeds up frontend and backend applications shutdown in docker, by making them correctly receive SIGTERM signal from docker.

`exec` makes frontend/backend app commands executed in entrypoint scripts main processes instead subprocesses of entrypoint script in their containers, which fails to pass termination signals to them.

`init: true` setting in docker makes apps executed with the entrypoint script subprocesses of dummy PID: 1 init process that will pass signals correctly to the application subprocess and avoid theorical issues with making frontend/backend app main processes.

https://buddy.works/tutorials/optimizing-dockerfile-for-node-js-part-1#reducing-the-number-of-processes
https://hynek.me/articles/docker-signals/#bonus-best-practice-let-someone-else-be-pid-1
https://engineeringblog.yelp.com/2016/01/dumb-init-an-init-for-docker.html

Before:
![obraz](https://github.com/CodeForPoznan/codeforpoznan.pl_v3/assets/35972878/47935b57-1b81-42f5-8653-f1988cde09d2)

After:
![obraz](https://github.com/CodeForPoznan/codeforpoznan.pl_v3/assets/35972878/c02e105b-d15b-4a53-aadf-bf90fa5c0106)

#### Migrations:
N/A

#### New imports / dependencies:
N/A

#### What tests do I need to run to validate this change:
N/A
