### PR TITLE
Feat: method to detect current copyright year

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -30,7 +30,7 @@
       "error",
       { "max": 2, "maxBOF": 0, "maxEOF": 1 }
     ],
-    "linebreak-style": ["error", "unix"],
+    "linebreak-style": "off",
     "newline-after-var": ["warn", "always"],
     "jest/no-disabled-tests": "warn",
     "jest/no-focused-tests": "error",

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,4 +1,5 @@
 {
     "tabWidth": 2,
-    "singleQuote": true
+    "singleQuote": true,
+    "endOfLine": "auto"
 }

--- a/frontend/src/components/HomePage/PageFooter/PageFooter.vue
+++ b/frontend/src/components/HomePage/PageFooter/PageFooter.vue
@@ -20,7 +20,7 @@ export default {
   data() {
     return {
       currentYear: new Date().getFullYear()
-    }
+    };
   }
-}
+};
 </script>

--- a/frontend/src/components/HomePage/PageFooter/PageFooter.vue
+++ b/frontend/src/components/HomePage/PageFooter/PageFooter.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <footer>Copyright © Code for Poznan 2023</footer>
+    <footer>Copyright © Code for Poznan {{ currentYear }}</footer>
   </div>
 </template>
 
@@ -14,3 +14,13 @@ footer {
   justify-content: center;
 }
 </style>
+
+<script>
+export default {
+  data() {
+    return {
+      currentYear: new Date().getFullYear()
+    }
+  }
+}
+</script>


### PR DESCRIPTION
Method to detect current year in footer copyright section

<img width="314" height="180" alt="obraz" src="https://github.com/user-attachments/assets/a7f43f4a-9f67-4062-83cf-6b82ad7eb0b7" />