### PR TITLE
Fix backend tech stack factory flake

### DIFF
--- a/backend/factories.py
+++ b/backend/factories.py
@@ -1,4 +1,5 @@
 from random import randint
+from uuid import uuid4
 
 import factory
 from factory import fuzzy
@@ -159,21 +160,29 @@ class TechStackFactory(BaseFactory):
     class Meta:
         model = TechStack
 
-    technology = factory.Faker("word")
+    technology = factory.Sequence(lambda n: f"technology-{n}")
     label = fuzzy.FuzzyChoice(["frontend", "backend", "DevOps", "UX"])
 
     @classmethod
     def _create(cls, model_class, *args, **kwargs):
         session = cls._meta.sqlalchemy_session
-        with session.no_autoflush:
-            existing = (
-                session.query(model_class)
-                .filter_by(technology=kwargs["technology"])
-                .first()
-            )
 
-        if existing:
-            kwargs["technology"] = cls.technology.generate({})
+        def technology_exists(technology):
+            pending_duplicate = any(
+                isinstance(obj, model_class) and obj.technology == technology
+                for obj in session.new
+            )
+            if pending_duplicate:
+                return True
+
+            with session.no_autoflush:
+                return (
+                    session.query(model_class).filter_by(technology=technology).first()
+                    is not None
+                )
+
+        while technology_exists(kwargs["technology"]):
+            kwargs["technology"] = f"technology-{uuid4().hex[:12]}"
 
         obj = super(TechStackFactory, cls)._create(model_class, *args, **kwargs)
 

--- a/backend/tests/test_factories.py
+++ b/backend/tests/test_factories.py
@@ -1,0 +1,19 @@
+from backend.factories import TechStackFactory
+
+
+def test_tech_stack_factory_batch_generates_unique_technologies(_db):
+    tech_stacks = TechStackFactory.create_batch(5)
+
+    _db.session.commit()
+
+    technologies = [tech_stack.technology for tech_stack in tech_stacks]
+    assert len(technologies) == len(set(technologies))
+
+
+def test_tech_stack_factory_handles_existing_technology(_db):
+    TechStackFactory(technology="Python")
+    duplicate = TechStackFactory(technology="Python")
+
+    _db.session.commit()
+
+    assert duplicate.technology != "Python"


### PR DESCRIPTION
## Summary
- make TechStackFactory generate deterministic unique technology values
- add regression tests for batch creation and duplicate fallback

## Verification
- python -m py_compile backend/factories.py backend/tests/test_factories.py
- Full local pytest not run: pipenv is not installed in this local environment. GitHub Actions should verify the backend workflow.