### PR TITLE
fix: licence link typo

### DIFF
--- a/frontend/src/assets/projects.js
+++ b/frontend/src/assets/projects.js
@@ -56,7 +56,7 @@ const projects = [
     imageAdress: require('@/assets/images/alinka.png'),
     license: 'MIT',
     licensePage:
-      'https://github.com/CodeForPoznan/alinka-pyside/blob/master/LICENSE',
+      'https://github.com/CodeForPoznan/alinka-pyside/blob/develop/LICENSE',
     name: 'Alinka',
     partner: [],
     stack: [


### PR DESCRIPTION
Fix link to alinka repository (def branch is `develop` not `master`)