### PR TITLE
fix(backend): make team factory deterministic

### DIFF
--- a/backend/factories.py
+++ b/backend/factories.py
@@ -127,10 +127,7 @@ class TeamFactory(BaseFactory):
         def team_exists(project_name, project_url):
             pending_duplicate = any(
                 isinstance(obj, model_class)
-                and (
-                    obj.project_name == project_name
-                    or obj.project_url == project_url
-                )
+                and (obj.project_name == project_name or obj.project_url == project_url)
                 for obj in session.new
             )
             if pending_duplicate:

--- a/backend/factories.py
+++ b/backend/factories.py
@@ -114,7 +114,7 @@ class TeamFactory(BaseFactory):
     class Meta:
         model = Team
 
-    project_name = factory.Faker("word", locale="pl_PL")
+    project_name = factory.Sequence(lambda n: f"project-{n + 1}")
     description = factory.Faker("paragraph", locale="pl_PL")
     project_url = factory.LazyAttribute(
         lambda obj: f"https://{obj.project_name}.codeforpoznan.test"
@@ -123,15 +123,34 @@ class TeamFactory(BaseFactory):
     @classmethod
     def _create(cls, model_class, *args, **kwargs):
         session = cls._meta.sqlalchemy_session
-        with session.no_autoflush:
-            existing = (
-                session.query(model_class)
-                .filter_by(project_name=kwargs["project_name"])
-                .first()
-            )
 
-        if existing:
-            project_name = cls.project_name.generate({})
+        def team_exists(project_name, project_url):
+            pending_duplicate = any(
+                isinstance(obj, model_class)
+                and (
+                    obj.project_name == project_name
+                    or obj.project_url == project_url
+                )
+                for obj in session.new
+            )
+            if pending_duplicate:
+                return True
+
+            with session.no_autoflush:
+                return (
+                    session.query(model_class)
+                    .filter(
+                        or_(
+                            model_class.project_name == project_name,
+                            model_class.project_url == project_url,
+                        )
+                    )
+                    .first()
+                    is not None
+                )
+
+        while team_exists(kwargs["project_name"], kwargs["project_url"]):
+            project_name = f"project-{uuid4().hex[:12]}"
             kwargs["project_name"] = project_name
             kwargs["project_url"] = f"https://{project_name}.codeforpoznan.test"
 

--- a/backend/tests/test_factories.py
+++ b/backend/tests/test_factories.py
@@ -1,4 +1,25 @@
-from backend.factories import TechStackFactory
+from backend.factories import TeamFactory, TechStackFactory
+
+
+def test_team_factory_batch_generates_unique_project_urls(_db):
+    teams = TeamFactory.create_batch(10)
+
+    _db.session.commit()
+
+    project_names = [team.project_name for team in teams]
+    project_urls = [team.project_url for team in teams]
+    assert len(project_names) == len(set(project_names))
+    assert len(project_urls) == len(set(project_urls))
+
+
+def test_team_factory_handles_existing_project_name(_db):
+    first_team = TeamFactory(project_name="duplicate-project")
+    duplicate_team = TeamFactory(project_name="duplicate-project")
+
+    _db.session.commit()
+
+    assert duplicate_team.project_name != first_team.project_name
+    assert duplicate_team.project_url != first_team.project_url
 
 
 def test_tech_stack_factory_batch_generates_unique_technologies(_db):


### PR DESCRIPTION
﻿## Summary
- make `TeamFactory` generate deterministic project names by default
- make duplicate handling check both pending session objects and existing DB rows for `project_name`/`project_url`
- add regression coverage for team factory batch uniqueness and explicit duplicate names

## Root cause
The staging workflow after PR #559 hit a backend test flake: fake teams could randomly reuse the same derived `project_url`, and SQLite correctly rejected the unique constraint.

## Validation
- `uv run python -m py_compile backend/factories.py backend/tests/test_factories.py`
- `git diff --check -- backend/factories.py backend/tests/test_factories.py`

Full local pytest was not runnable in this local environment: no ready `pipenv`/`pytest` environment was available, and Docker daemon was not running. GitHub Actions should run the backend test workflow.
